### PR TITLE
Conform to the C99 standard

### DIFF
--- a/material/1-l-2/ref/tfl.h
+++ b/material/1-l-2/ref/tfl.h
@@ -1,4 +1,4 @@
-#include <stdlib.h>
+#include <stdint.h>
 typedef uint16_t tfl16_t;
 
 tfl16_t  tfl_sign(tfl16_t value);


### PR DESCRIPTION
stdlib.h is not guaranteed to work on all systems, while stdint.h is.